### PR TITLE
Correct output of Memory Usage, fix for free_ram, max_ram, used_ram added current_ram

### DIFF
--- a/src/main/java/com/github/games647/scoreboardstats/variables/GeneralVariables.java
+++ b/src/main/java/com/github/games647/scoreboardstats/variables/GeneralVariables.java
@@ -30,23 +30,23 @@ public class GeneralVariables implements ReplaceManager.Replaceable {
         }
 
         if ("%free_ram%".equals(variable)) {
-            return (int)( Runtime.getRuntime().freeMemory() / ( 1024 * 1024 ) );
+            return (int)( Runtime.getRuntime().freeMemory() / 1024L / 1024L );
         }
 
         if ("%max_ram%".equals(variable)) {
-            return (int)( Runtime.getRuntime().maxMemory() / ( 1024 * 1024 ) );
+            return (int)( Runtime.getRuntime().maxMemory() / ( 1024L * 1024L ) );
         }
         
         if ("%current_ram%".equals(variable)) {
-            return (int)( Runtime.getRuntime().totalMemory() / ( 1024 * 1024 ) );
+            return (int)( Runtime.getRuntime().totalMemory() / ( 1024L * 1024L ) );
         }
 
         if ("%used_ram%".equals(variable)) {
-            return (int)( ( Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() ) / ( 1024 * 1024 ) );
+            return (int)( ( Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory() ) / ( 1024L * 1024L ) );
         }
 
         if ("%used%ram%".equals(variable)) {
-            return ((int)(Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 100 / (int)Runtime.getRuntime().totalMemory());
+            return (int)((Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) * 100L / Runtime.getRuntime().totalMemory());
         }
 
         if ("%date%".equals(variable)) {


### PR DESCRIPTION
I've also fixed the memory output to display correct values and added the variable "%current_ram%"

PROOF: http://prntscr.com/42q3sp ( differnce of 2mb in free_mem is my speed of print screening after executing the command )

---

Long/int division resulted in unexpected values, making sure the value
is in the range of long fixes this problem.

TO DO: Fix used%ram
