### PR TITLE
Fix GriefPrevention variables (#121)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -334,9 +334,9 @@
         </dependency>
         
         <dependency>
-            <groupId>com.github.BigScary</groupId>
+            <groupId>com.github.TechFortress</groupId>
             <artifactId>GriefPrevention</artifactId>
-            <version>-9ec0837038-1</version>
+            <version>5186739d3a</version>
         </dependency>
         
         <dependency>

--- a/src/main/java/com/github/games647/scoreboardstats/variables/defaults/GriefPreventionVariables.java
+++ b/src/main/java/com/github/games647/scoreboardstats/variables/defaults/GriefPreventionVariables.java
@@ -23,13 +23,12 @@ public class GriefPreventionVariables extends DefaultReplaceAdapter<GriefPrevent
         } else if ("bonus_claim_blocks".equals(variable)) {
             replaceEvent.setScore(playerData.getBonusClaimBlocks());
         } else if ("remaining_blocks".equals(variable)) {
-            int totalBlocks = playerData.getAccruedClaimBlocks() + playerData.getBonusClaimBlocks();
-            replaceEvent.setScore(totalBlocks);
+            replaceEvent.setScore(playerData.getRemainingClaimBlocks());
         } else if ("total_blocks".equals(variable)) {
-            replaceEvent.setScore(playerData.getBonusClaimBlocks());
+            int totalBlocks = playerData.getAccruedClaimBlocks() + playerData.getBonusClaimBlocks() + getPlugin().dataStore.getGroupBonusBlocks(player.getUniqueId());
+            replaceEvent.setScore(totalBlocks);
         } else if ("group_bonus_blocks".equals(variable)) {
-            replaceEvent.setScore(-1);
-//            replaceEvent.setScore(getPlugin().dataStore.getGroupBonusBlocks(player.getUniqueId()));
+            replaceEvent.setScore(getPlugin().dataStore.getGroupBonusBlocks(player.getUniqueId()));
         }
     }
 }


### PR DESCRIPTION
1. `remaining_blocks` now uses `playerData.getRemainingClaimBlocks()`
2. `group_bonus_blocks`: method `getGroupBonusBlocks(UUID)` is [now public](https://github.com/TechFortress/GriefPrevention/pull/4/commits/806f68967d3326d8b2159fa5d6e14ac73dda481e), so I uncommented the code in variable replacement.
2. Fixed `total_blocks`